### PR TITLE
[FIX] Allow to listen several streams at once

### DIFF
--- a/lib/redis_stream/subscriber.rb
+++ b/lib/redis_stream/subscriber.rb
@@ -14,7 +14,8 @@ module RedisStream
       end
 
       # listen for up to 10 messages forever
-      messages = RedisStream.client.xreadgroup(group, consumer, streams, ">", count: 1, block: 0)
+      ids = streams.map { [">"] }
+      messages = RedisStream.client.xreadgroup(group, consumer, streams, ids, count: 1, block: 0)
 
       messages.each do |stream, stream_messages|
         stream_messages.each do |message_id, message_hash|


### PR DESCRIPTION
When trying to listen to several streams at once we faced the error message:

```bash
Redis::CommandError: ERR Unbalanced XREAD list of streams: for each stream key an ID or '$' must be specified. (redis://localhost:6379/3) (Redis::CommandError)
```

In order to fix that we need to specify each ids for each key

```ruby
# redis gem
      # @param group    [String]        the consumer group name
      # @param consumer [String]        the consumer name
      # @param keys     [Array<String>] one or multiple stream keys
      # @param ids      [Array<String>] one or multiple entry ids
      # @param opts     [Hash]          several options for `XREADGROUP` command
      def xreadgroup(group, consumer, keys, ids, count: nil, block: nil, noack: nil)
	# code
      end
```

This fix change the way we call this method to be inline with redis gem and make it works for our use case.