### PR TITLE
[FIX] Memory usage: CAP the stream

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_stream (0.1.3)
+    redis_stream (0.1.5)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     redis_stream (0.1.5)
+
 GEM
   remote: https://rubygems.org/
   specs:

--- a/lib/redis_stream/publisher.rb
+++ b/lib/redis_stream/publisher.rb
@@ -10,7 +10,7 @@ module RedisStream
 
     def publish(name, data = {})
       data = {"name" => name, "json" => JSON.generate(data)}
-      RedisStream.client.xadd(@stream_key, data)
+      RedisStream.client.xadd(@stream_key, data, maxlen: 1000, approximate: true)
     end
   end
 end

--- a/lib/redis_stream/version.rb
+++ b/lib/redis_stream/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedisStream
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/dummy_redis.rb
+++ b/spec/dummy_redis.rb
@@ -8,7 +8,7 @@ class DummyRedisClient
     @streams[stream] << data
   end
 
-  def xreadgroup(group, consumer, streams, condition, count: 1, block: 5000)
+  def xreadgroup(group, consumer, streams, condition, count: 1, block: 5000, noack: false)
     @streams[streams] ||= []
     @streams[streams].map.with_index do |data, index|
       [streams, {index => data}]


### PR DESCRIPTION
Make sure we keep our stream in check using the maxlen option. According to the documentation. That is a possible solution for our memory usage issue. 

# Documentation

https://redis.io/docs/latest/commands/xadd/

## Capped streams

XADD incorporates the same semantics as the XTRIM command - refer to its documentation page for more information. This allows adding new entries and keeping the stream's size in check with a single call to XADD, effectively capping the stream with an arbitrary threshold. Although exact trimming is possible and is the default, due to the internal representation of steams it is more efficient to add an entry and trim stream with XADD using almost exact trimming (the ~ argument).

For example, calling XADD in the following form:

```
XADD mystream MAXLEN ~ 1000 * ... entry fields here ...
```
Will add a new entry but will also evict old entries so that the stream will contain only 1000 entries, or at most a few tens more.

<img width="1179" alt="Screenshot 2024-09-25 at 10 12 31" src="https://github.com/user-attachments/assets/7e93d7e3-8a1e-4bc6-9fe8-49c08a1ec12c">
