### PR TITLE
added loop to the listen method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis_stream (0.1.5)
+    redis_stream (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/redis_stream/subscriber.rb
+++ b/lib/redis_stream/subscriber.rb
@@ -13,13 +13,15 @@ module RedisStream
         create_group(stream_key, group)
       end
 
-      # listen for up to 10 messages forever
-      ids = Array.new(streams.length, ">")
-      messages = RedisStream.client.xreadgroup(group, consumer, streams, ids, count: 1, block: 0, noack: true)
-
-      messages.each do |stream, stream_messages|
-        stream_messages.each do |message_id, message_hash|
-          yield(stream, message_id, message_hash["name"], JSON.parse(message_hash["json"]))
+      loop do
+        # listen for up to 10 messages forever
+        ids = Array.new(streams.length, ">")
+        messages = RedisStream.client.xreadgroup(group, consumer, streams, ids, count: 1, block: 0, noack: true)
+  
+        messages.each do |stream, stream_messages|
+          stream_messages.each do |message_id, message_hash|
+            yield(stream, message_id, message_hash["name"], JSON.parse(message_hash["json"]))
+          end
         end
       end
     end

--- a/lib/redis_stream/subscriber.rb
+++ b/lib/redis_stream/subscriber.rb
@@ -17,7 +17,7 @@ module RedisStream
         # listen for up to 10 messages forever
         ids = Array.new(streams.length, ">")
         messages = RedisStream.client.xreadgroup(group, consumer, streams, ids, count: 1, block: 0, noack: true)
-  
+
         messages.each do |stream, stream_messages|
           stream_messages.each do |message_id, message_hash|
             yield(stream, message_id, message_hash["name"], JSON.parse(message_hash["json"]))

--- a/lib/redis_stream/version.rb
+++ b/lib/redis_stream/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedisStream
-  VERSION = "0.1.5"
+  VERSION = "0.2.0"
 end

--- a/spec/redis_stream/subscriber_spec.rb
+++ b/spec/redis_stream/subscriber_spec.rb
@@ -9,12 +9,24 @@ RSpec.describe RedisStream::Subscriber do
 
   describe ".listen" do
     it "subscribes to the stream" do
-      described_class.listen(streams: "stream_test") do |message|
-        expect(message).to eq("test")
+      allow(described_class).to receive(:loop).and_yield.twice
+
+      allow(RedisStream.client).to receive(:xreadgroup).and_return([
+        ["stream_test", [["message_id", {"name" => "test", "json" => "{}"}]]]
+      ])
+
+      described_class.listen(streams: "stream_test") do |stream, message_id, name, json|
+        expect(stream).to eq("stream_test")
+        expect(message_id).to eq("message_id")
+        expect(name).to eq("test")
+        expect(json).to eq({})
       end
 
-      described_class.listen(streams: ["stream_test"]) do |message|
-        expect(message).to eq("test")
+      described_class.listen(streams: ["stream_test"]) do |stream, message_id, name, json|
+        expect(stream).to eq("stream_test")
+        expect(message_id).to eq("message_id")
+        expect(name).to eq("test")
+        expect(json).to eq({})
       end
     end
   end


### PR DESCRIPTION
### The problem: ###
The `RedisStream::Subscriber.listen` method is called in a loop for all our services which leads to creating consumer groups for every iteration in a loop. This leads to a massive overhead to the redis instance:
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/b097eebe-2fc7-445a-8482-649fbee66690">
### The solution: ###
Move loop inside listen method and remove all loops from all our services.
Before:
```
loop do
  RedisStream::Subscriber.listen(streams: subscribed_to_streams) do |stream, message_id, message_name, payload|
    ....
  end
end
```

After:
```
RedisStream::Subscriber.listen(streams: subscribed_to_streams) do |stream, message_id, message_name, payload|
  ....
end
```