### PR TITLE
[FEATURE] Implement reconnect logic and exponential backoff in Subscriber

### DIFF
--- a/lib/redis_stream/subscriber.rb
+++ b/lib/redis_stream/subscriber.rb
@@ -2,19 +2,19 @@
 
 module RedisStream
   class Subscriber
-    def self.listen(streams:, group: nil, consumer: nil, &block)
+    INITIAL_BACKOFF = 0.5
+    MAX_BACKOFF = 30.0
+
+    def self.listen(streams:, group: nil, consumer: nil)
       group ||= RedisStream.config.group_id
       consumer ||= RedisStream.config.consumer_id
       streams = Array(streams)
 
       return unless streams.any?
 
-      streams.each do |stream_key|
-        create_group(stream_key, group)
-      end
+      ensure_groups(streams, group)
 
       loop do
-        # listen for up to 10 messages forever
         ids = Array.new(streams.length, ">")
         messages = RedisStream.client.xreadgroup(group, consumer, streams, ids, count: 1, block: 0, noack: true)
 
@@ -23,13 +23,62 @@ module RedisStream
             yield(stream, message_id, message_hash["name"], JSON.parse(message_hash["json"]))
           end
         end
+      rescue Redis::BaseConnectionError => e
+        log("disconnected from redis (#{e.class}: #{e.message})")
+        wait_for_reconnect
+      rescue Redis::CommandError => e
+        raise unless e.message.include?("NOGROUP")
+
+        log("NOGROUP detected; recreating consumer groups")
+        ensure_groups(streams, group)
       end
     end
 
+    def self.wait_for_reconnect
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      backoff = INITIAL_BACKOFF
+      attempt = 0
+      loop do
+        attempt += 1
+        log("reconnect attempt ##{attempt}: sleeping #{backoff}s before ping")
+        sleep(backoff)
+        begin
+          RedisStream.client.ping
+          downtime = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+          log("reconnected to redis after #{attempt} attempt(s); downtime #{format_duration(downtime)}")
+          return
+        rescue Redis::BaseConnectionError => e
+          log("reconnect attempt ##{attempt} failed: #{e.class}: #{e.message}")
+          backoff = [backoff * 2, MAX_BACKOFF].min
+        end
+      end
+    end
+
+    def self.format_duration(seconds)
+      return format("%.2fs", seconds) if seconds < 60
+
+      minutes, secs = seconds.divmod(60)
+      return format("%dm %ds", minutes, secs) if minutes < 60
+
+      hours, mins = minutes.divmod(60)
+      format("%dh %dm %ds", hours, mins, secs)
+    end
+
+    def self.ensure_groups(streams, group)
+      streams.each { |stream_key| create_group(stream_key, group) }
+    end
+
     def self.create_group(stream_key, group_name)
+      log("creating consumer group #{group_name.inspect} on stream #{stream_key.inspect}")
       RedisStream.client.xgroup(:create, stream_key, group_name, "$", mkstream: true)
     rescue Redis::CommandError => e
-      raise e unless e.message.include?("BUSYGROUP") # the group already existing is fine
+      raise unless e.message.include?("BUSYGROUP")
+
+      log("consumer group #{group_name.inspect} on stream #{stream_key.inspect} already exists")
+    end
+
+    def self.log(message)
+      warn("[redis_stream] #{message}")
     end
   end
 end

--- a/lib/redis_stream/subscriber.rb
+++ b/lib/redis_stream/subscriber.rb
@@ -2,83 +2,90 @@
 
 module RedisStream
   class Subscriber
-    INITIAL_BACKOFF = 0.5
-    MAX_BACKOFF = 30.0
+    INITIAL_RECONNECT_BACKOFF = 0.5
+    MAX_RECONNECT_BACKOFF = 30.0
 
-    def self.listen(streams:, group: nil, consumer: nil)
-      group ||= RedisStream.config.group_id
-      consumer ||= RedisStream.config.consumer_id
-      streams = Array(streams)
+    class << self
+      def listen(streams:, group: RedisStream.config.group_id, consumer: RedisStream.config.consumer_id)
+        return unless (streams = Array(streams)).any?
 
-      return unless streams.any?
+        loop do
+          RedisStream.client.xreadgroup(
+            group,                              # consumer group name (must exist; XGROUP CREATE handles that)
+            consumer,                           # this consumer's name within the group; identifies who owns delivered messages
+            streams,                            # stream keys to read from
+            Array.new(streams.length, ">"),     # per-stream start ID; ">" means "only new messages, never redelivered"
+            count: 1,                           # max messages returned per stream per call
+            block: 0,                           # block forever waiting for new messages (ms; 0 = no timeout)
+            noack: true                         # skip the pending-entries list — at-most-once delivery, no XACK/XCLAIM recovery
+          ).each do |stream, stream_messages|
+            stream_messages.each do |message_id, message_hash|
+              yield(stream, message_id, message_hash["name"], JSON.parse(message_hash["json"]))
+            end
+          end
+        rescue Redis::BaseConnectionError => e
+          log("Disconnected from Redis (#{e.class}: #{e.message})")
 
-      ensure_groups(streams, group)
+          reconnect_with_delay
+        rescue Redis::CommandError => e
+          raise unless e.message.include?("NOGROUP")
 
-      loop do
-        ids = Array.new(streams.length, ">")
-        messages = RedisStream.client.xreadgroup(group, consumer, streams, ids, count: 1, block: 0, noack: true)
+          ensure_groups_in_place!(streams, group)
+        end
+      end
 
-        messages.each do |stream, stream_messages|
-          stream_messages.each do |message_id, message_hash|
-            yield(stream, message_id, message_hash["name"], JSON.parse(message_hash["json"]))
+      def reconnect_with_delay
+        started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        backoff    = INITIAL_RECONNECT_BACKOFF                                # standard:disable Layout/ExtraSpacing
+        attempt    = 0                                                        # standard:disable Layout/ExtraSpacing
+
+        loop do
+          attempt += 1
+
+          log("Reconnect attempt ##{attempt}: sleeping #{backoff}s before ping")
+
+          sleep(backoff)
+
+          begin
+            RedisStream.client.ping
+            downtime = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+
+            log("Reconnected to Redis after #{attempt} attempt(s); downtime #{format_duration(downtime)}")
+
+            return
+          rescue Redis::BaseConnectionError => e
+            log("Reconnect attempt ##{attempt} failed: #{e.class}: #{e.message}")
+
+            backoff = [backoff * 2, MAX_RECONNECT_BACKOFF].min
           end
         end
-      rescue Redis::BaseConnectionError => e
-        log("disconnected from redis (#{e.class}: #{e.message})")
-        wait_for_reconnect
-      rescue Redis::CommandError => e
-        raise unless e.message.include?("NOGROUP")
-
-        log("NOGROUP detected; recreating consumer groups")
-        ensure_groups(streams, group)
       end
-    end
 
-    def self.wait_for_reconnect
-      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      backoff = INITIAL_BACKOFF
-      attempt = 0
-      loop do
-        attempt += 1
-        log("reconnect attempt ##{attempt}: sleeping #{backoff}s before ping")
-        sleep(backoff)
-        begin
-          RedisStream.client.ping
-          downtime = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
-          log("reconnected to redis after #{attempt} attempt(s); downtime #{format_duration(downtime)}")
-          return
-        rescue Redis::BaseConnectionError => e
-          log("reconnect attempt ##{attempt} failed: #{e.class}: #{e.message}")
-          backoff = [backoff * 2, MAX_BACKOFF].min
+      def ensure_groups_in_place!(streams, group)
+        streams.each do |stream_key|
+          log("Creating consumer group #{group.inspect} on stream #{stream_key.inspect}")
+
+          RedisStream.client.xgroup(:create, stream_key, group, "$", mkstream: true)
+        rescue Redis::CommandError => e
+          raise unless e.message.include?("BUSYGROUP")
+
+          log("Consumer group #{group.inspect} on stream #{stream_key.inspect} already exists")
         end
       end
-    end
 
-    def self.format_duration(seconds)
-      return format("%.2fs", seconds) if seconds < 60
+      def format_duration(seconds)
+        return format("%.2fs", seconds) if seconds < 60
 
-      minutes, secs = seconds.divmod(60)
-      return format("%dm %ds", minutes, secs) if minutes < 60
+        minutes, secs = seconds.divmod(60)
+        return format("%dm %ds", minutes, secs) if minutes < 60
 
-      hours, mins = minutes.divmod(60)
-      format("%dh %dm %ds", hours, mins, secs)
-    end
+        hours, mins = minutes.divmod(60)
+        format("%dh %dm %ds", hours, mins, secs)
+      end
 
-    def self.ensure_groups(streams, group)
-      streams.each { |stream_key| create_group(stream_key, group) }
-    end
-
-    def self.create_group(stream_key, group_name)
-      log("creating consumer group #{group_name.inspect} on stream #{stream_key.inspect}")
-      RedisStream.client.xgroup(:create, stream_key, group_name, "$", mkstream: true)
-    rescue Redis::CommandError => e
-      raise unless e.message.include?("BUSYGROUP")
-
-      log("consumer group #{group_name.inspect} on stream #{stream_key.inspect} already exists")
-    end
-
-    def self.log(message)
-      warn("[redis_stream] #{message}")
+      def log(message)
+        warn("[redis_stream] #{message}")
+      end
     end
   end
 end

--- a/spec/dummy_redis.rb
+++ b/spec/dummy_redis.rb
@@ -20,4 +20,8 @@ class DummyRedisClient
 
   def xack(stream, group, message_id)
   end
+
+  def ping
+    "PONG"
+  end
 end

--- a/spec/redis_stream/subscriber_spec.rb
+++ b/spec/redis_stream/subscriber_spec.rb
@@ -1,19 +1,22 @@
+require "redis"
+
 RSpec.describe RedisStream::Subscriber do
-  let(:stream_key) { "test" }
+  let(:stream_key) { "stream_test" }
 
   before do
     RedisStream.configure do |config|
       config.redis(DummyRedisClient.new)
     end
+    allow(described_class).to receive(:sleep)
+    allow(described_class).to receive(:log)
   end
 
   describe ".listen" do
     it "subscribes to the stream" do
       allow(described_class).to receive(:loop).and_yield.twice
 
-      allow(RedisStream.client).to receive(:xreadgroup).and_return([
-        ["stream_test", [["message_id", {"name" => "test", "json" => "{}"}]]]
-      ])
+      allow(RedisStream.client).to receive(:xreadgroup)
+        .and_return([["stream_test", [["message_id", {"name" => "test", "json" => "{}"}]]]])
 
       described_class.listen(streams: "stream_test") do |stream, message_id, name, json|
         expect(stream).to eq("stream_test")
@@ -27,6 +30,107 @@ RSpec.describe RedisStream::Subscriber do
         expect(message_id).to eq("message_id")
         expect(name).to eq("test")
         expect(json).to eq({})
+      end
+    end
+
+    def stub_loop_iterations(n)
+      allow(described_class).to receive(:loop) do |&block|
+        n.times { block.call }
+      end
+    end
+
+    context "when xreadgroup raises a connection error" do
+      it "calls wait_for_reconnect and resumes instead of propagating" do
+        stub_loop_iterations(2)
+        call_count = 0
+        allow(RedisStream.client).to receive(:xreadgroup) do
+          call_count += 1
+          raise Redis::CannotConnectError, "connection refused" if call_count == 1
+
+          []
+        end
+
+        expect(described_class).to receive(:wait_for_reconnect).and_call_original
+
+        expect do
+          described_class.listen(streams: stream_key) { |*| }
+        end.not_to raise_error
+      end
+    end
+
+    describe ".wait_for_reconnect" do
+      it "returns once ping succeeds" do
+        allow(RedisStream.client).to receive(:ping).and_return("PONG")
+
+        expect(described_class).to receive(:sleep).once
+
+        described_class.wait_for_reconnect
+      end
+
+      it "keeps retrying with exponential backoff until ping succeeds" do
+        ping_calls = 0
+        allow(RedisStream.client).to receive(:ping) do
+          ping_calls += 1
+          raise Redis::CannotConnectError, "still down" if ping_calls < 3
+
+          "PONG"
+        end
+
+        sleeps = []
+        allow(described_class).to receive(:sleep) { |s| sleeps << s }
+
+        described_class.wait_for_reconnect
+
+        expect(sleeps.size).to eq(3)
+        expect(sleeps[1]).to be > sleeps[0]
+        expect(sleeps[2]).to be > sleeps[1]
+      end
+
+      it "caps backoff at MAX_BACKOFF" do
+        ping_calls = 0
+        allow(RedisStream.client).to receive(:ping) do
+          ping_calls += 1
+          raise Redis::CannotConnectError, "down" if ping_calls < 20
+
+          "PONG"
+        end
+
+        sleeps = []
+        allow(described_class).to receive(:sleep) { |s| sleeps << s }
+
+        described_class.wait_for_reconnect
+
+        expect(sleeps.last).to eq(RedisStream::Subscriber::MAX_BACKOFF)
+      end
+    end
+
+    context "when xreadgroup raises NOGROUP" do
+      it "recreates the group and retries without sleeping" do
+        stub_loop_iterations(2)
+        call_count = 0
+        allow(RedisStream.client).to receive(:xreadgroup) do
+          call_count += 1
+          raise Redis::CommandError, "NOGROUP No such key 'x' or consumer group 'y'" if call_count == 1
+
+          []
+        end
+
+        expect(RedisStream.client).to receive(:xgroup).twice.and_call_original
+        expect(described_class).not_to receive(:sleep)
+
+        described_class.listen(streams: stream_key) { |*| }
+      end
+    end
+
+    context "when xreadgroup raises a non-NOGROUP CommandError" do
+      it "propagates the error" do
+        allow(described_class).to receive(:loop).and_yield
+        allow(RedisStream.client).to receive(:xreadgroup)
+          .and_raise(Redis::CommandError, "WRONGTYPE Operation against a key holding the wrong kind of value")
+
+        expect do
+          described_class.listen(streams: stream_key) { |*| }
+        end.to raise_error(Redis::CommandError, /WRONGTYPE/)
       end
     end
   end

--- a/spec/redis_stream/subscriber_spec.rb
+++ b/spec/redis_stream/subscriber_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RedisStream::Subscriber do
     end
 
     context "when xreadgroup raises a connection error" do
-      it "calls wait_for_reconnect and resumes instead of propagating" do
+      it "calls reconnect_with_delay and resumes instead of propagating" do
         stub_loop_iterations(2)
         call_count = 0
         allow(RedisStream.client).to receive(:xreadgroup) do
@@ -50,7 +50,7 @@ RSpec.describe RedisStream::Subscriber do
           []
         end
 
-        expect(described_class).to receive(:wait_for_reconnect).and_call_original
+        expect(described_class).to receive(:reconnect_with_delay).and_call_original
 
         expect do
           described_class.listen(streams: stream_key) { |*| }
@@ -58,13 +58,13 @@ RSpec.describe RedisStream::Subscriber do
       end
     end
 
-    describe ".wait_for_reconnect" do
+    describe ".reconnect_with_delay" do
       it "returns once ping succeeds" do
         allow(RedisStream.client).to receive(:ping).and_return("PONG")
 
         expect(described_class).to receive(:sleep).once
 
-        described_class.wait_for_reconnect
+        described_class.reconnect_with_delay
       end
 
       it "keeps retrying with exponential backoff until ping succeeds" do
@@ -79,14 +79,14 @@ RSpec.describe RedisStream::Subscriber do
         sleeps = []
         allow(described_class).to receive(:sleep) { |s| sleeps << s }
 
-        described_class.wait_for_reconnect
+        described_class.reconnect_with_delay
 
         expect(sleeps.size).to eq(3)
         expect(sleeps[1]).to be > sleeps[0]
         expect(sleeps[2]).to be > sleeps[1]
       end
 
-      it "caps backoff at MAX_BACKOFF" do
+      it "caps backoff at MAX_RECONNECT_BACKOFF" do
         ping_calls = 0
         allow(RedisStream.client).to receive(:ping) do
           ping_calls += 1
@@ -98,9 +98,9 @@ RSpec.describe RedisStream::Subscriber do
         sleeps = []
         allow(described_class).to receive(:sleep) { |s| sleeps << s }
 
-        described_class.wait_for_reconnect
+        described_class.reconnect_with_delay
 
-        expect(sleeps.last).to eq(RedisStream::Subscriber::MAX_BACKOFF)
+        expect(sleeps.last).to eq(RedisStream::Subscriber::MAX_RECONNECT_BACKOFF)
       end
     end
 
@@ -115,7 +115,7 @@ RSpec.describe RedisStream::Subscriber do
           []
         end
 
-        expect(RedisStream.client).to receive(:xgroup).twice.and_call_original
+        expect(RedisStream.client).to receive(:xgroup).and_call_original
         expect(described_class).not_to receive(:sleep)
 
         described_class.listen(streams: stream_key) { |*| }


### PR DESCRIPTION
## Summary

Make `RedisStream::Subscriber.listen` survive Redis restarts. Previously the listener crashed on any connection drop; now it logs the disconnect, retries with exponential backoff using `PING` to detect recovery, and resumes consumption. If Redis comes back without persistence (or the stream/group was wiped), `NOGROUP` is detected and the consumer groups are recreated automatically.

## What changed

`lib/redis_stream/subscriber.rb`:

- Wrapped the `xreadgroup` loop with rescues for `Redis::BaseConnectionError` and `Redis::CommandError`.
- On connection error: call `wait_for_reconnect`, which probes `PING` with exponential backoff (0.5s → 30s cap, doubling) until Redis is reachable, then resumes the consume loop.
- On `NOGROUP`: call `ensure_groups` to recreate consumer groups on all streams, then resume.
- Other `CommandError`s still propagate (e.g. `WRONGTYPE`).
- Group creation extracted to `ensure_groups(streams, group)`, called both on startup and after `NOGROUP`.
- Diagnostic logging added at every state change (disconnect, each reconnect attempt + outcome, reconnect success with downtime, group creation, `NOGROUP` recovery). Logs go to stderr via `warn` with a `[redis_stream]` prefix.

`PING` is used (not `xreadgroup`) for recovery detection because `xreadgroup` blocks waiting for messages — without a probe that returns immediately, we couldn't distinguish "Redis is back but no traffic" from "Redis still down."

## Behavior

| Scenario                                     | Before           | After                                          |
| -------------------------------------------- | ---------------- | ---------------------------------------------- |
| Redis restart                                | Listener crashes | Logs disconnect, retries with backoff, resumes |
| Redis flushed / different instance (NOGROUP) | Listener crashes | Recreates groups, resumes                      |
| Network blip                                 | Listener crashes | Reconnects (typically <1s)                     |
| `WRONGTYPE` or other command errors          | Propagates       | Propagates (unchanged)                         |
| Broken poison message handler                | Propagates       | Propagates (unchanged)                         |

Backoff caps at 30s. Downtime is measured with `Process::CLOCK_MONOTONIC` (immune to NTP jumps) and reported in the reconnect log: `reconnected to redis after 4 attempt(s); downtime 3.50s`.

## Sample output

<img width="1041" height="216" alt="image" src="https://github.com/user-attachments/assets/2a724e99-30dd-4e79-a342-efa63e05f1df" />
