### PR TITLE
[FEATURE] Expose maxlen configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Welcome to your new gem! In this directory, you'll find the files you need to be
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:
+
 ```ruby
   # Gemfile
   $ gem "redis_stream", git: "https://github.com/test-IO/redis_stream"
@@ -12,17 +13,23 @@ Install the gem and add to the application's Gemfile by executing:
 
 ## Usage
 
-Initialize the gem with the Redis client you want to use in you `config/initializers/
+Initialize the gem with the Redis client you want to use in you `config/initializers/`
 
 ```ruby
 RedisStream.configure do |config|
-  config.redis(Redis.new(url: "redis://localhost:6379/0"))
+  config.redis_url("redis://localhost:6379/0")
   config.group("group_name")
   config.consumer("consumer_name")
   config.stream("stream_name")
+  config.logging_stream("logging_stream_name")
+  config.maxlen(200) # optional, defaults to 100
 end
 ```
+
+`maxlen` is optional and caps the stream length when publishing (passed to Redis `XADD` with the approximate flag). If omitted, the default of 100 is used.
+
 ### Subscribe
+
 To subscribe you will always need to provide the name of the stream you want to listen to, you can also provide an array of stream.
 
 ```ruby

--- a/lib/redis_stream/configuration.rb
+++ b/lib/redis_stream/configuration.rb
@@ -1,12 +1,13 @@
 module RedisStream
   class Configuration
-    attr_accessor :client, :group_id, :consumer_id, :stream_key, :logging_stream_key
+    attr_accessor :client, :group_id, :consumer_id, :stream_key, :logging_stream_key, :max_length
 
     def initialize
       @group = "group"
       @consumer = "consumer"
       @stream_key = "stream"
       @logging_stream_key = "logging_stream"
+      @max_length = 100
     end
 
     def redis(client)
@@ -31,6 +32,10 @@ module RedisStream
 
     def logging_stream(logging_stream)
       @logging_stream_key = logging_stream
+    end
+
+    def maxlen(max_length)
+      @max_length = max_length
     end
   end
 end

--- a/lib/redis_stream/publisher.rb
+++ b/lib/redis_stream/publisher.rb
@@ -10,7 +10,7 @@ module RedisStream
 
     def publish(name, data = {})
       data = {"name" => name, "json" => JSON.generate(data)}
-      RedisStream.client.xadd(@stream_key, data, maxlen: 1000, approximate: true)
+      RedisStream.client.xadd(@stream_key, data, maxlen: RedisStream.config.max_length, approximate: true)
     end
   end
 end


### PR DESCRIPTION
## Summary

  - Make `maxlen` configurable on `RedisStream::Publisher` via the same DSL as other options (`config.maxlen(200)`), instead of being hard-coded to `1000`.
  - Default is `100` when not set; option is optional.
  - README updated with the new option and a small cleanup (`redis_url`, `logging_stream`).

  ## Changes

  - `lib/redis_stream/configuration.rb`: added `max_length` attribute (default `100`) and `maxlen(value)` setter.
  - `lib/redis_stream/publisher.rb`: `xadd` now uses `RedisStream.config.max_length`.
  - `README.md`: documented `maxlen`, `logging_stream`, and switched the example to `redis_url`.