### PR TITLE
[FIX] Handle Redis loading errors during stream listening and reconnection

### DIFF
--- a/lib/redis_stream/subscriber.rb
+++ b/lib/redis_stream/subscriber.rb
@@ -28,9 +28,15 @@ module RedisStream
 
           reconnect_with_delay
         rescue Redis::CommandError => e
-          raise unless e.message.include?("NOGROUP")
+          if loading_error?(e)
+            log("Redis is loading dataset (#{e.message})")
 
-          ensure_groups_in_place!(streams, group)
+            reconnect_with_delay
+          elsif nogroup_error?(e)
+            ensure_groups_in_place!(streams, group)
+          else
+            raise
+          end
         end
       end
 
@@ -55,6 +61,12 @@ module RedisStream
             return
           rescue Redis::BaseConnectionError => e
             log("Reconnect attempt ##{attempt} failed: #{e.class}: #{e.message}")
+
+            backoff = [backoff * 2, MAX_RECONNECT_BACKOFF].min
+          rescue Redis::CommandError => e
+            raise unless loading_error?(e)
+
+            log("Reconnect attempt ##{attempt}: Redis still loading dataset (#{e.message})")
 
             backoff = [backoff * 2, MAX_RECONNECT_BACKOFF].min
           end
@@ -85,6 +97,14 @@ module RedisStream
 
       def log(message)
         warn("[redis_stream] #{message}")
+      end
+
+      def loading_error?(error)
+        error.message.start_with?("LOADING")
+      end
+
+      def nogroup_error?(error)
+        error.message.include?("NOGROUP")
       end
     end
   end

--- a/spec/redis_stream/subscriber_spec.rb
+++ b/spec/redis_stream/subscriber_spec.rb
@@ -104,6 +104,55 @@ RSpec.describe RedisStream::Subscriber do
       end
     end
 
+    context "when xreadgroup raises LOADING" do
+      it "calls reconnect_with_delay and resumes instead of propagating" do
+        stub_loop_iterations(2)
+        call_count = 0
+        allow(RedisStream.client).to receive(:xreadgroup) do
+          call_count += 1
+          raise Redis::CommandError, "LOADING Dragonfly is loading the dataset in memory" if call_count == 1
+
+          []
+        end
+
+        expect(described_class).to receive(:reconnect_with_delay).and_call_original
+        allow(RedisStream.client).to receive(:ping).and_return("PONG")
+
+        expect do
+          described_class.listen(streams: stream_key) { |*| }
+        end.not_to raise_error
+      end
+    end
+
+    context "when ping raises LOADING during reconnect" do
+      it "keeps retrying with exponential backoff until ping succeeds" do
+        ping_calls = 0
+        allow(RedisStream.client).to receive(:ping) do
+          ping_calls += 1
+          raise Redis::CommandError, "LOADING Dragonfly is loading the dataset in memory" if ping_calls < 3
+
+          "PONG"
+        end
+
+        sleeps = []
+        allow(described_class).to receive(:sleep) { |s| sleeps << s }
+
+        described_class.reconnect_with_delay
+
+        expect(sleeps.size).to eq(3)
+        expect(sleeps[1]).to be > sleeps[0]
+        expect(sleeps[2]).to be > sleeps[1]
+      end
+
+      it "re-raises non-LOADING CommandError from ping" do
+        allow(RedisStream.client).to receive(:ping)
+          .and_raise(Redis::CommandError, "ERR something else")
+
+        expect { described_class.reconnect_with_delay }
+          .to raise_error(Redis::CommandError, /something else/)
+      end
+    end
+
     context "when xreadgroup raises NOGROUP" do
       it "recreates the group and retries without sleeping" do
         stub_loop_iterations(2)


### PR DESCRIPTION
```
rake aborted!
Redis::CommandError: LOADING Dragonfly is loading the dataset in memory (redis://dragonflydb:6379) (Redis::CommandError)
/home/appuser/.bundle/ruby/3.4.0/gems/redis-client-0.26.2/lib/redis_client/connection_mixin.rb:43:in 'RedisClient::ConnectionMixin#call'
/home/appuser/.bundle/ruby/3.4.0/gems/redis-client-0.26.2/lib/redis_client.rb:420:in 'block (2 levels) in RedisClient#blocking_call_v'.......
```